### PR TITLE
feat: [iid_base_app] Empty base project

### DIFF
--- a/bricks/iid_base_app/CHANGELOG.md
+++ b/bricks/iid_base_app/CHANGELOG.md
@@ -1,3 +1,7 @@
-# 0.1.0+1
+# 0.2.0
 
-- TODO: Describe initial release.
+- Use `--empty` for a cleaner base project
+
+# 0.1.0
+
+- Initial Release

--- a/bricks/iid_base_app/brick.yaml
+++ b/bricks/iid_base_app/brick.yaml
@@ -4,7 +4,7 @@ description: Creates a new Base App
 # The following defines the version and build number for your brick.
 # A version number is three numbers separated by dots, like 1.2.34
 # followed by an optional build number (separated by a +).
-version: 0.1.0+1
+version: 0.2.0
 
 # The following defines the environment for the current brick.
 # It includes the version of mason that the brick requires.

--- a/bricks/iid_base_app/hooks/pre_gen.dart
+++ b/bricks/iid_base_app/hooks/pre_gen.dart
@@ -16,6 +16,7 @@ Future<void> run(HookContext context) async {
     'flutter',
     [
       'create',
+      '--empty',
       '--platforms=$platforms',
       '--org=$org',
       name,


### PR DESCRIPTION
Use `--empty` flag when running `flutter create` to have a cleaner base project (no comments in pubspec)

Closes #20 